### PR TITLE
remove sklearn as it's no longer supported

### DIFF
--- a/Code/Install_Packages.txt
+++ b/Code/Install_Packages.txt
@@ -1,7 +1,6 @@
 h5py
 numpy
 scikit-learn
-sklearn
 keras
 opencv-python
 pyttsx3

--- a/Code/cnn_model_train.py
+++ b/Code/cnn_model_train.py
@@ -7,7 +7,7 @@ from keras.models import Sequential
 from keras.layers import Dense
 from keras.layers import Dropout
 from keras.layers import Flatten
-from keras.layers.convolutional import Conv2D
+from tensorflow.keras.layers import Conv2D
 from keras.layers.convolutional import MaxPooling2D
 from keras.utils import np_utils
 from keras.callbacks import ModelCheckpoint


### PR DESCRIPTION
The standalone sklearn package on PyPI is deliberately deprecated to prevent confusion and potential security risks; the maintainers require you to use the real package name scikit-learn.